### PR TITLE
A few tweaks to streamline your code and make things easier

### DIFF
--- a/src/main/java/net/orangejewce/pmmo_xp_bottles/init/ModCreativeModTabs.java
+++ b/src/main/java/net/orangejewce/pmmo_xp_bottles/init/ModCreativeModTabs.java
@@ -3,6 +3,7 @@ package net.orangejewce.pmmo_xp_bottles.init;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.api.distmarker.Dist;
@@ -34,11 +35,9 @@ public class ModCreativeModTabs {
     @SubscribeEvent
     public static void addItemsToTabs(BuildCreativeModeTabContentsEvent event) {
         if (event.getTab() == NEW_TAB.get()) {
-            PmmoXpBottlesModItems.ALL_BOTTLES.values().forEach(item -> {
-                ItemStack stack = new ItemStack(item.get());
-                ((XpBottleItem)item.get()).initializeNBT(stack);  // Ensure default values are set
-                event.accept(stack);
-            });
+            PmmoXpBottlesModItems.ALL_BOTTLES.keySet().stream().sorted().toList().stream()
+                    .map(key -> PmmoXpBottlesModItems.ALL_BOTTLES.get(key).get().getDefaultInstance())
+                    .forEach(event::accept);
         }
     }
 }

--- a/src/main/java/net/orangejewce/pmmo_xp_bottles/init/PmmoXpBottlesModItems.java
+++ b/src/main/java/net/orangejewce/pmmo_xp_bottles/init/PmmoXpBottlesModItems.java
@@ -1,12 +1,14 @@
 package net.orangejewce.pmmo_xp_bottles.init;
 
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import net.orangejewce.pmmo_xp_bottles.items.XpBottleItem;
 import net.orangejewce.pmmo_xp_bottles.pmmobottlesMod;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,25 +17,18 @@ public class PmmoXpBottlesModItems {
 
     public static final Map<String, RegistryObject<Item>> ALL_BOTTLES = new HashMap<>();
 
-    private static final String[] SKILLS = {
-            "archery", "woodcutting", "mining", "building", "excavation", "farming",
-            "agility", "endurance", "combat", "gunslinging", "smithing", "crafting",
-            "magic", "slayer", "hunter", "taming", "cooking", "alchemy",
-            "engineering", "fishing", "sailing", "swimming"
-    };
-
-    private static final String[] TIERS = {"common", "rare", "epic"};
-
     static {
-        for (String skill : SKILLS) {
-            for (String tier : TIERS) {
+        for (XpBottleItem.Skill skill : XpBottleItem.Skill.values()) {
+            for (Rarity tier : Arrays.stream(Rarity.values()).filter(rarity -> rarity != Rarity.UNCOMMON).toList()) {
                 make(skill, tier);
             }
         }
     }
 
-    private static RegistryObject<Item> make(String skill, String tier) {
-        String registryName = skill + "_" + tier + "_bottle";
+
+
+    private static RegistryObject<Item> make(XpBottleItem.Skill skill, Rarity tier) {
+        String registryName = skill.skill() + "_" + tier.name().toLowerCase() + "_bottle";
         RegistryObject<Item> obj = REGISTRY.register(registryName, () -> new XpBottleItem(skill, tier));
         ALL_BOTTLES.put(registryName, obj);
         return obj;


### PR DESCRIPTION
- Moved all skill references to an enum which is used throughout the codebase for reusability
- replaced Tier with Minecraft's built-in `Rarity` and updated all references to use this instead.
  - This also allows for adding UNCOMMON at a later dater.  Alternatively you could downshift rare and epic to uncommon and rare respectively and then add the higher epic.  I just didn't want to refactor all of your filenames if that wasn't an intended outcome.
- in the `finishUsingItem` method replaced the registry lookup to ALL_BOTTLES with a reference to the item itself.  
- Removed some helper methods that were only used once and were otherwise reduced to one line.  namely `applySkillEffect`.